### PR TITLE
More throughout grouping into subcycles

### DIFF
--- a/src/experiment.py
+++ b/src/experiment.py
@@ -50,7 +50,7 @@ class Subcycle:
         name = name.casefold()
         
         
-        if name in ["transmission", "t"]:
+        if name in ["transmission", "t", "rf"]:
             self.transmits.append(time)
         elif name.startswith("ch"):
             

--- a/src/experiment.py
+++ b/src/experiment.py
@@ -1,68 +1,82 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 import matplotlib.pyplot as plt
-from src.timeInterval import TimeInterval
-from src import rtp
+from typing import Union
 
+from src import rtp
+from src.timeInterval import TimeInterval
 from src.const import km, µs, c
 
-class Experiment:
+class Subcycle:
     """
-    Handling timings for transmitter and receiver channels
+    Handling timings for transmission, receiver channels. More properties will 
+    follow?
     """
-    def __init__(self):
+    def __init__(self, begin: float = 0, end: Union[float, bool] = False):
         self.transmits = []
         self.receive = {}
-        self.instruction_cycle = TimeInterval(0,0)
-        self.subcycles = []
-        self.other_settings = {}
+        self.prop = {}
         
-    def add_setting_time(self, name: str, time: TimeInterval):
+        self._begin = begin
+        self._end = end
         
-        if hasattr(self, name):
-            self.name.append(time)
+    @property
+    def end(self):
+        time = 0
+        if self._end:
+            time = self._end
         else:
-            # Add setting if not existing
-            if name not in self.other_settings:
-                self.other_settings[name] = []
-                
-            self.other_settings[name].append(time)
+            raise NotImplementedError("""Loop through all transmits, receives 
+                                      and other settings and use the last one""")
+        return time
+    @property
+    def begin(self):
+        return self._begin
+                                      
+    def add_time(self, name: str, time: TimeInterval):
+        """
+        Adds TimeInterval to relevant attribute of Subcycle.
+        
+        :param name: declares what the interval is for: Possibilities are:
+            - "transmission"/"t" - transmission
+            - "ch<some number>" - reception in channel with specified number
+        :type name: str
+        :param time: interval with on and off time of attribute
+        :type time: TimeInterval
+
+        """
+        
+        # Dont care about large or small letters
+        name = name.casefold()
+        
+        
+        if name in ["transmission", "t"]:
+            self.transmits.append(time)
+        elif name.startswith("ch"):
             
-    def add_transmit_time(self, time: TimeInterval):
-        # TODO: Check for overlapping 
-        # TODO: Sort
-        self.transmits.append(time)
-    
-    def add_receive_time(self, channel: str, time: TimeInterval):
-        if channel not in self.receive:
-            self.receive[channel] = []
+            channel = int(name[2:])
             
-        self.receive[channel].append(time)
+            if channel not in self.receive:
+                self.receive[channel] = []
+            self.receive[channel].append(time)
+        else:
+            if name not in self.prop:
+                self.prop[name] = []
+            self.prop[name].append(time)
+            
+    def plot(self):
         
-    def add_subcycle(self, time: TimeInterval):
-        self.subcycles.append(time)
-    
-    def add_stop_time(self, time: float):
-        self.instruction_cycle.end = time
-    
-    def plot(self, subcycle: int = 1):
-        
-        if subcycle <= 0 and subcycle > len(self.subcycles):
-            raise ValueError("Select a subcycle between 1 and {len(self.subcycles)}, not {subcycle}")
-        
-        plot_interval = self.subcycles[subcycle-1]
+        plot_interval = TimeInterval(self.begin, self.end)
         
         plt.figure()
         plt.grid(which = 'major')
         for transmit in self.transmits:
-            if transmit.within(plot_interval):
-                rtp.plot_transmit(transmit, plot_interval)
+            rtp.plot_transmit(transmit, plot_interval)
         
         cols = ["black", "red", "green", "orange", "brown", "grey"]
         for i, receives in enumerate(self.receive.values()):
             for receive in receives:
-                if receive.within(plot_interval):
-                    rtp.plot_receive(receive, plot_interval, color=cols[i])
+                rtp.plot_receive(receive, plot_interval, color=cols[i])
             
         # Hard-coded, not good, but as long as we have no reception, 
         # we cant do better...
@@ -72,4 +86,43 @@ class Experiment:
         #             plot_receive(receive, self.instruction_cycle)
         # plot_add_range_label(rmin)
         # plot_add_range_label(rmax)
+        
+class Experiment:
+    """
+    Handling timings for transmitter and receiver channels
+    """
+    def __init__(self):
+        self.subcycles = []
+        
+    def add_subcycle(self, subcycle: Subcycle):
+        self.subcycles.append(subcycle)
+    
+    
+    # def plot(self, subcycle: int = 1):
+        
+    #     if subcycle <= 0 and subcycle > len(self.subcycles):
+    #         raise ValueError("Select a subcycle between 1 and {len(self.subcycles)}, not {subcycle}")
+        
+    #     plot_interval = self.subcycles[subcycle-1]
+        
+    #     plt.figure()
+    #     plt.grid(which = 'major')
+    #     for transmit in self.transmits:
+    #         if transmit.within(plot_interval):
+    #             rtp.plot_transmit(transmit, plot_interval)
+        
+    #     cols = ["black", "red", "green", "orange", "brown", "grey"]
+    #     for i, receives in enumerate(self.receive.values()):
+    #         for receive in receives:
+    #             if receive.within(plot_interval):
+    #                 rtp.plot_receive(receive, plot_interval, color=cols[i])
+            
+    #     # Hard-coded, not good, but as long as we have no reception, 
+    #     # we cant do better...
+    #     plt.ylim(0, 1000)
+    #     # for ch in self.receive_channels:
+    #     #     for receive in ch:
+    #     #             plot_receive(receive, self.instruction_cycle)
+    #     # plot_add_range_label(rmin)
+    #     # plot_add_range_label(rmax)
         

--- a/src/tarlan.py
+++ b/src/tarlan.py
@@ -204,16 +204,7 @@ class Tarlan():
             exp.add_subcycle(subcycle)
         
         return exp
-    def cmds_from_tlan(self, filename: str = "") -> list[Command]:
-        cmd_list = []
-        with open(filename) as file:
-            for il, line in enumerate(file):
-                cmds = parse_line(line, il+1)
-                for cmd in cmds:
-                    cmd_list.append(cmd)
-                    if cmd.cmd == "REP":
-                        break
-        return cmd_list
+
                     
     def from_tlan(self, filename: str = "") -> None:
         """
@@ -223,7 +214,7 @@ class Tarlan():
         :type file_name: str, optional
         
         """
-        cmd_list = self.cmds_from_tlan(filename)
+        cmd_list = tarlan_parser(filename)
         
         for cmd in cmd_list:
             
@@ -405,35 +396,25 @@ def parse_line(line: str, line_number: int = 0) -> list[Command]:
         
     return commands
         
-def tarlan_parser(filename: str) -> list[ParseSubcycle]:
+
+def tarlan_parser(filename: str = "") -> list[Command]:
     """
-    Parse tlan file by running parse_line for every line of code. Commands are
-        grouped in ParseSubcycle objects
+    Parse tlan file. Commands are returned in the same order as they appear in 
+    the file.
     
-    :param filename: Path to tlan file, defaults to ""
+    :param filename: filename, defaults to ""
     :type filename: str
-    :raises FileNotFoundError: when file is not found / does not exist
-    :return: commands grouped in Subcycles.
-    :rtype: list[ParseSubcycle]
+    :return: list of Command objects
+    :rtype: list[Command]
 
     """
-    
-    cycle = []
-    
+    cmd_list = []
     with open(filename) as file:
         for il, line in enumerate(file):
             cmds = parse_line(line, il+1)
             for cmd in cmds:
-                
-                # print(cmd)
-                if cmd.cmd == "SETTCR":
-                    try:
-                        cycle.append(subcycle)
-                    except NameError:
-                        pass
-                    subcycle = ParseSubcycle(cmd.t, cmd.line)
-                subcycle.add_command(cmd)
+                cmd_list.append(cmd)
                 if cmd.cmd == "REP":
-                    cycle.append(subcycle)
                     break
-    return cycle
+    return cmd_list
+

--- a/src/tarlan.py
+++ b/src/tarlan.py
@@ -259,7 +259,10 @@ class Tarlan():
             for cmd in subcycle.commands:
                 if cmd.cmd == "REP":
                     break
-                self.exec_cmd(cmd)
+                if cmd.cmd == "SETTCR":
+                    self.SETTCR(cmd.t, cmd.line)
+                else:
+                    self.exec_cmd(cmd)
         if cmd.cmd != "REP":
             raise TarlanError("The program stopped with other command than 'REP'", cmd.line)
         self.subcycles.turn_off(cmd.t, cmd.line)
@@ -295,6 +298,10 @@ class Tarlan():
             
         if self.streams["-"].is_off:
             self.streams["-"].turn_on(time, line)
+            
+    def SETTCR(self, time: float, line: int):
+        "Set reference time in time control"
+        self.TCR = time
         
                 
     def exec_cmd(self, cmd: Command):
@@ -326,7 +333,7 @@ class Tarlan():
             "PHA0": self.PHA0,
             "PHA180": self.PHA180,
             "ALLOFF": self.ALLOFF,
-            "SETTCR": do_nothing,  # Is not handeled here?
+            "SETTCR": do_nothing,  # Is not handeled here!
             "BUFLIP": do_nothing,  # Too technical here
             "STC": do_nothing,  # Too technical here
             }
@@ -342,7 +349,7 @@ class Tarlan():
             execute_command[freq] = do_nothing
         
         ''' 
-        Silent warnings on setting single bits 4 or 5 in tarnsmit and receive 
+        Silent warnings on setting single bits 4 or 5 in transmit and receive 
         controllers. These go to ADC samplegate, but are not of interest here.
         '''
         for i in [4, 5]:
@@ -355,6 +362,7 @@ class Tarlan():
         
         
         if cmd.cmd in execute_command.keys():
+            # print(self.TCR, cmd.t)
             execute_command[cmd.cmd](self.TCR + cmd.t, cmd.line)
         else:
             print(f"Command {cmd.cmd}, called from line {cmd.line} ",

--- a/src/tarlan.py
+++ b/src/tarlan.py
@@ -234,6 +234,8 @@ class Tarlan():
                 # All other subcycles except for that SETTCR that appears 
                 # directly before REP command at the end of the file
                 elif cmd.t != 0:
+                    # Turn off phase shifts (# TODO: at RF turnoff)
+                    self.PHA_OFF(cmd.t, cmd.line)
                     self.subcycles.turn_off(cmd.t, cmd.line, self.streams)
                     
                     # Delete connection to last subcycle streams¨
@@ -242,6 +244,7 @@ class Tarlan():
                     self.subcycles.turn_on(cmd.t, cmd.line)
                 self.SETTCR(cmd.t, cmd.line)
             elif cmd.cmd == "REP":
+                self.PHA_OFF(cmd.t, cmd.line)
                 self.subcycles.turn_off(cmd.t, cmd.line, self.streams)
                 self.cycle.turn_off(cmd.t, cmd.line)
             else:
@@ -278,6 +281,15 @@ class Tarlan():
         if self.streams["-"].is_off:
             self.streams["-"].turn_on(time, line)
             
+    def PHA_OFF(self, time: float, line: int):
+        """
+        Turn off phase shifts. This is not a TARLAN command, but needed to 
+        able to plot phase shifts later.
+        """
+        for ps in ["+", "-"]:
+            if self.streams[ps].is_on:
+                self.streams[ps].turn_off(time, line)
+            
     def SETTCR(self, time: float, line: int):
         "Set reference time in time control"
         self.TCR = time
@@ -309,8 +321,8 @@ class Tarlan():
             "CALOFF": self.streams["CAL"].turn_off,
             "BEAMON": self.streams["BEAM"].turn_on,
             "BEAMOFF": self.streams["BEAM"].turn_off,
-            "PHA0": do_nothing,#self.PHA0,
-            "PHA180": do_nothing,#self.PHA180,
+            "PHA0": self.PHA0,
+            "PHA180": self.PHA180,
             "ALLOFF": self.ALLOFF,
             "SETTCR": do_nothing,  # Is not handeled here!
             "BUFLIP": do_nothing,  # Too technical here

--- a/src/tarlanError.py
+++ b/src/tarlanError.py
@@ -17,8 +17,8 @@ class TarlanError(Exception):
 
         """
         if line_number > 0:
-            super().__init__("The .tlan file has errors in line", line_number, 
-                             ":", msg)
+            super().__init__("The .tlan file has errors in line " \
+                             + str(line_number) + ":", msg)
         else:
             super().__init__("The TARLAN command has errors:", msg)
 

--- a/test/test_tarlan.py
+++ b/test/test_tarlan.py
@@ -4,7 +4,7 @@ import pytest
 import tempfile
 import os
 
-from src.tarlan import µs, parse_line, TarlanError, Command, Subcycle, Tarlan
+from src.tarlan import µs, parse_line, TarlanError, Command, ParseSubcycle, Tarlan
 
 
 def test_parse_line():
@@ -39,7 +39,7 @@ def test_command():
     assert str(cmd2) == "39: 135.0 ALLOFF"
     
 def test_subcycle():
-    s = Subcycle(line = 2)
+    s = ParseSubcycle(line = 2)
     
     assert s.start == 0
     assert s.startline == 2
@@ -120,8 +120,8 @@ def test_tarlan_program():
     os.remove(file.name)
     
     exp = tlan.to_exp()
-    assert exp.transmits[0].begin == 40*µs
-    assert exp.transmits[0].end == 220*µs
-    assert exp.transmits[1].begin == (40)*µs
-    assert exp.transmits[1].end == (220)*µs
+    assert exp.subcycles[0].transmits[0].begin == pytest.approx(40*µs)
+    assert exp.subcycles[0].transmits[0].end == pytest.approx(220*µs)
+    assert exp.subcycles[1].transmits[0].begin == pytest.approx((40 + 1505)*µs)
+    assert exp.subcycles[1].transmits[0].end == pytest.approx((220 + 1505)*µs)
     


### PR DESCRIPTION
Divide experiment into subcycles holding its own streams
Move tarlan subcycle creating to when commands are looped over. Gives less noisy code.
